### PR TITLE
Tooling updates. Use file set for headers.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -157,9 +157,3 @@ CheckOptions:
     value: "lower_case"
   - key: "readability-identifier-naming.VirtualMethodCase"
     value: "lower_case"
-  - key: "misc-include-cleaner.IgnoreHeaders"
-    value: "\
-      asio/io_context.hpp;\
-      bark/asio_io_context_wrapper.hpp;\
-      fmt/std.h;\
-      "

--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -3,15 +3,21 @@ name: "Install LLVM and Clang"
 description: "Installs LLVM and Clang on CI runners"
 inputs:
   version:
-    description: "Which version of LLVM to install. E.g '19 or 'clang-19'."
+    description: "Which version of LLVM to install. E.g. '19'"
     required: true
 runs:
   using: "composite"
   steps:
     - name: Install LLVM and Clang
       shell: bash
+      env:
+        LLVM_VERSION: ${{ inputs.version }}
       run: |
-        LLVM_VERSION=`echo ${{ inputs.version }} | cut -d'-' -f 2`
+        # if clang-version is already installed return
+        if which clang-$LLVM_VERSION > /dev/null; then
+          exit 0
+        fi
+
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
         sudo ./llvm.sh $LLVM_VERSION

--- a/.github/actions/install-clang/action.yml
+++ b/.github/actions/install-clang/action.yml
@@ -3,7 +3,7 @@ name: "Install LLVM and Clang"
 description: "Installs LLVM and Clang on CI runners"
 inputs:
   version:
-    description: "Which version of LLVM to install. E.g '18 or 'clang-18'."
+    description: "Which version of LLVM to install. E.g '19 or 'clang-19'."
     required: true
 runs:
   using: "composite"

--- a/.github/actions/install-gcc/action.yml
+++ b/.github/actions/install-gcc/action.yml
@@ -3,15 +3,20 @@ name: "Install GCC"
 description: "Installs GCC on CI runners"
 inputs:
   version:
-    description: "Which version of GCC to install. E.g. '14' or 'gcc-14'"
+    description: "Which version of GCC to install. E.g. '14'"
     required: true
 runs:
   using: "composite"
   steps:
     - name: Install GCC
       shell: bash
+      env:
+        GCC_VERSION: ${{ inputs.version }}
       run: |
-        GCC_VERSION=`echo ${{ inputs.version }} | cut -d'-' -f 2`
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-        sudo apt-get update -q
+        if ! apt-cache show  "gcc-$GCC_VERSION" > /dev/null; then
+          # Add test repository if gcc version is not available.
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -q
+        fi
+
         sudo apt-get install gcc-$GCC_VERSION g++-$GCC_VERSION g++-$GCC_VERSION-multilib -y -q

--- a/.github/actions/install-gcc/action.yml
+++ b/.github/actions/install-gcc/action.yml
@@ -3,7 +3,7 @@ name: "Install GCC"
 description: "Installs GCC on CI runners"
 inputs:
   version:
-    description: "Which version of GCC to install. E.g. '13' or 'gcc-13'"
+    description: "Which version of GCC to install. E.g. '14' or 'gcc-14'"
     required: true
 runs:
   using: "composite"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_COMMIT: "c82f74667287d3dc386bce81e44964370c91a289"
+  VCPKG_COMMIT: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,17 +208,17 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-24.04"
+          - { name: "ubuntu", version: "24.04"}
         compiler:
-          - "gcc-11"
-          - "gcc-14"
-          - "clang-19"
+          - { name: "gcc", version: "11" }
+          - { name: "gcc", version: "14" }
+          - { name: "clang", version: "19" }
 
         include:
-          - os: "windows-2022"
-            compiler: "msvc"
+          - os: { name: "windows", version: "2022"}
+            compiler: { name: "msvc", version: "" }
 
-    runs-on: ${{ matrix.os }}
+    runs-on: "${{ matrix.os.name }}-${{ matrix.os.version }}"
 
     steps:
       - uses: actions/checkout@v4
@@ -226,31 +226,31 @@ jobs:
           lfs: true
 
       - name: General Build Dependencies
-        if: contains(matrix.os, 'ubuntu')
+        if: ${{ matrix.os.name == 'ubuntu' }}
         run: sudo apt-get install ninja-build -y -q
 
       - uses: ./.github/actions/install-gcc
-        if: ${{ contains(matrix.compiler, 'gcc') && contains(matrix.os, 'ubuntu') }}
+        if: ${{ matrix.compiler.name == 'gcc' && matrix.os.name == 'ubuntu' }}
         with:
-          version: ${{ matrix.compiler }}
+          version: ${{ matrix.compiler.version }}
 
       - uses: ./.github/actions/install-clang
-        if: ${{ contains(matrix.compiler, 'clang') && contains(matrix.os, 'ubuntu') }}
+        if: ${{ matrix.compiler.name == 'clang' && matrix.os.name == 'ubuntu' }}
         with:
-          version: ${{ matrix.compiler }}
+          version: ${{ matrix.compiler.version }}
 
       - name: Install vcpkg
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: "${{ env.VCPKG_COMMIT }}"
-          cache-version: "test-${{ contains(matrix.os, 'ubuntu') && 'Linux' || 'Windows' }}-${{ matrix.compiler }}"
+          cache-version: "test-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}"
           cache-restore-keys: |
-            vcpkg-${{ contains(matrix.os, 'ubuntu') && 'Linux' || 'Windows' }}-test-${{ matrix.compiler }}-
+            vcpkg-${{ matrix.os.name == 'ubuntu' && 'Linux' || 'Windows' }}-test-${{ matrix.compiler.name }}-${{ matrix.compiler.version }}-
 
       - name: Configure
         shell: pwsh
         run: |
-          cmake "--preset=ci-$("${{ matrix.os }}".split("-")[0])-${{ matrix.compiler }}"
+          cmake "--preset=ci-${{ matrix.os.name }}-${{ matrix.compiler.name }}${{ matrix.compiler.version && '-' || '' }}${{ matrix.compiler.version }}"
 
       - name: Build
         run: cmake --build build --config Release -j 4
@@ -263,9 +263,9 @@ jobs:
         run: ctest --output-on-failure --no-tests=error -C Release -j 4
 
       - name: Benchmarks
-        if: ${{ !contains(matrix.os, 'windows') }}
+        if: ${{ matrix.os.name != 'windows' }}
         run: ./build/benchmarks/bark_benchmarks --benchmark_display_aggregates_only=true
 
       - name: Benchmarks
-        if: ${{ contains(matrix.os, 'windows') }}
+        if: ${{ matrix.os.name == 'windows' }}
         run: ./build/benchmarks/Release/bark_benchmarks --benchmark_display_aggregates_only=true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,7 @@ jobs:
           lfs: true
 
       - name: General Build Dependencies
-        run: >-
-          sudo apt-get update -q && sudo apt-get install ninja-build -y -q
+        run: sudo apt-get install ninja-build -y -q
 
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
@@ -127,16 +126,15 @@ jobs:
           lfs: true
 
       - name: General Build Dependencies
-        run: >-
-          sudo apt-get update -q && sudo apt-get install ninja-build -y -q
+        run: sudo apt-get install ninja-build -y -q
 
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
         with:
           version: "19"
 
-      - name: Install sonar-scanner and build-wrapper
-        uses: SonarSource/sonarcloud-github-c-cpp@v3
+      - name: Install Sonar build-wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v5
 
       - name: Install vcpkg
         uses: friendlyanon/setup-vcpkg@v1
@@ -161,12 +159,12 @@ jobs:
       - name: Test and code coverage
         run: cmake --build build/coverage -t ccov-all -j 4
 
-      - name: Run sonar-scanner
+      - name: SonarQube Scan
+        uses: SonarSource/sonarqube-scan-action@v5
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          sonar-scanner \
+        with:
+          args: >
             --define sonar.cfamily.compile-commands=${{ env.BUILD_WRAPPER_OUT_DIR }}/compile_commands.json
 
   vcpkg-build:
@@ -180,8 +178,7 @@ jobs:
           lfs: true
 
       - name: General Build Dependencies
-        run: >-
-          sudo apt-get update -q && sudo apt-get install ninja-build -y -q
+        run: sudo apt-get install ninja-build -y -q
 
       - name: Install vcpkg
         uses: friendlyanon/setup-vcpkg@v1
@@ -230,8 +227,7 @@ jobs:
 
       - name: General Build Dependencies
         if: contains(matrix.os, 'ubuntu')
-        run: |
-          sudo apt-get install ninja-build -y -q
+        run: sudo apt-get install ninja-build -y -q
 
       - uses: ./.github/actions/install-gcc
         if: ${{ contains(matrix.compiler, 'gcc') && contains(matrix.os, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,25 +31,23 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
-
-      - name: Install codespell
-        run: pip3 install codespell
+          python-version: "3.12"
 
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
         with:
-          version: "18"
+          version: "19"
 
       - name: Format Check
-        run: cmake -D FORMAT_COMMAND=clang-format-18 -P cmake/lint.cmake
+        run: cmake -D FORMAT_COMMAND=clang-format-19 -P cmake/lint.cmake
 
       - name: Dependency Setup Check
         run: python3 ./tools/check_install_packages_match.py
 
       - name: Spell check
-        if: ${{ !cancelled() }}
-        run: cmake -P cmake/spell.cmake
+        run: |
+          pip3 install codespell
+          cmake -P cmake/spell.cmake
 
       - name: Test version bumped
         if: github.ref != 'refs/heads/main'
@@ -85,16 +83,16 @@ jobs:
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
         with:
-          version: "18"
+          version: "19"
 
       - name: Install vcpkg
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: "${{ env.VCPKG_COMMIT }}"
-          cache-version: "sanitize-clang-18"
+          cache-version: "sanitize-clang-19"
           cache-restore-keys: |
-            vcpkg-Linux-sanitize-clang-18-
-            vcpkg-Linux-test-clang-18-
+            vcpkg-Linux-sanitize-clang-19-
+            vcpkg-Linux-test-clang-19-
 
       - name: Configure
         run: |
@@ -135,7 +133,7 @@ jobs:
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
         with:
-          version: "18"
+          version: "19"
 
       - name: Install sonar-scanner and build-wrapper
         uses: SonarSource/sonarcloud-github-c-cpp@v3
@@ -144,10 +142,10 @@ jobs:
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: "${{ env.VCPKG_COMMIT }}"
-          cache-version: "sonar-clang-18"
+          cache-version: "sonar-clang-19"
           cache-restore-keys: |
-            vcpkg-Linux-sonar-clang-18-
-            vcpkg-Linux-test-clang-18-
+            vcpkg-Linux-sonar-clang-19-
+            vcpkg-Linux-test-clang-19-
 
       - name: Configure
         run: |
@@ -189,15 +187,15 @@ jobs:
         uses: friendlyanon/setup-vcpkg@v1
         with:
           committish: "${{ env.VCPKG_COMMIT }}"
-          cache-version: "vcpkg-build-clang-18"
+          cache-version: "vcpkg-build-clang-19"
           cache-restore-keys: |
-            vcpkg-Linux-vcpkg-build-clang-18-
-            vcpkg-Linux-test-clang-18-
+            vcpkg-Linux-vcpkg-build-clang-19-
+            vcpkg-Linux-test-clang-19-
 
       - name: Install LLVM and Clang
         uses: ./.github/actions/install-clang
         with:
-          version: "18"
+          version: "19"
 
       - name: Configure
         run: |
@@ -216,8 +214,8 @@ jobs:
           - "ubuntu-24.04"
         compiler:
           - "gcc-11"
-          - "gcc-13"
-          - "clang-18"
+          - "gcc-14"
+          - "clang-19"
 
         include:
           - os: "windows-2022"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "testMate.cpp.test.executables": "build/**/test/*",
-    "clang-format.executable": "clang-format-18",
-    "clangd.path": "clangd-18",
+    "clang-format.executable": "clang-format-19",
+    "clangd.path": "clangd-19",
     "clangd.arguments": [
         "-compile-commands-dir=${workspaceFolder}/build/dev"
     ],

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.30)
 include(cmake/prelude.cmake)
 project(
     bark
-    VERSION 0.3.0
+    VERSION 0.4.0
     DESCRIPTION "Datadog Agent client for C++"
     HOMEPAGE_URL "https://github.com/twig-energy/bark"
     LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.30)
 
 include(cmake/prelude.cmake)
 project(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.30)
 include(cmake/prelude.cmake)
 project(
     bark
-    VERSION 0.4.0
+    VERSION 0.3.1
     DESCRIPTION "Datadog Agent client for C++"
     HOMEPAGE_URL "https://github.com/twig-energy/bark"
     LANGUAGES CXX

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,29 +24,49 @@ find_package(SPSCQueue CONFIG REQUIRED)
 
 # ---- Declare library ----
 
-add_library(
-    bark
-    source/asio_client.cpp
-    source/client.cpp
-    source/count.cpp
-    source/event.cpp
-    source/gauge.cpp
-    source/histogram.cpp
-    source/mpmc_client.cpp
-    source/spsc_client.cpp
-    source/udp_client.cpp
-)
+add_library(bark)
 add_library(twig::bark ALIAS bark)
+
+target_sources(
+    bark
+    PRIVATE source/asio_client.cpp
+            source/client.cpp
+            source/count.cpp
+            source/event.cpp
+            source/gauge.cpp
+            source/histogram.cpp
+            source/mpmc_client.cpp
+            source/spsc_client.cpp
+            source/udp_client.cpp
+    PUBLIC
+    FILE_SET HEADERS
+             BASE_DIRS include
+             FILES include/bark/asio_client.hpp
+                   include/bark/asio_io_context_wrapper.hpp
+                   include/bark/bark.hpp
+                   include/bark/client.hpp
+                   include/bark/count.hpp
+                   include/bark/datagram.hpp
+                   include/bark/event.hpp
+                   include/bark/feature_detection.hpp
+                   include/bark/gauge.hpp
+                   include/bark/histogram.hpp
+                   include/bark/i_datadog_client.hpp
+                   include/bark/mpmc_client.hpp
+                   include/bark/noop_client.hpp
+                   include/bark/number_of_io_threads.hpp
+                   include/bark/sample_rate.hpp
+                   include/bark/spsc_client.hpp
+                   include/bark/tags.hpp
+                   include/bark/udp_client.hpp
+)
 
 include(GenerateExportHeader)
 generate_export_header(
     bark
-    BASE_NAME
-    bark
-    EXPORT_FILE_NAME
-    export/bark/export.hpp
-    CUSTOM_CONTENT_FROM_VARIABLE
-    pragma_suppress_c4251
+    BASE_NAME bark
+    EXPORT_FILE_NAME export/bark/export.hpp
+    CUSTOM_CONTENT_FROM_VARIABLE pragma_suppress_c4251
 )
 
 if (NOT BUILD_SHARED_LIBS)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 5,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 24,
+    "minor": 30,
     "patch": 0
   },
   "configurePresets": [
@@ -25,7 +25,7 @@
       "name": "clang-tidy",
       "hidden": true,
       "cacheVariables": {
-        "CMAKE_CXX_CLANG_TIDY": "clang-tidy-18;--header-filter=^${sourceDir}/(include|src|source|test)"
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy-19;--header-filter=^${sourceDir}/(include|src|source|test)"
       }
     },
     {
@@ -81,6 +81,19 @@
       }
     },
     {
+      "name": "clang-19",
+      "hidden": true,
+      "environment": {
+        "CXX": "clang++-19",
+        "CC": "clang-19",
+        "LLVM_SYMBOLIZER_PATH": "llvm-symbolizer-19"
+      },
+      "cacheVariables": {
+        "LLVM_COV_COMMAND": "llvm-cov-19",
+        "LLVM_PROFDATA_COMMAND": "llvm-profdata-19"
+      }
+    },
+    {
       "name": "gcc-11",
       "hidden": true,
       "environment": {
@@ -102,6 +115,14 @@
       "environment": {
         "CXX": "g++-13",
         "CC": "gcc-13"
+      }
+    },
+    {
+      "name": "gcc-14",
+      "hidden": true,
+      "environment": {
+        "CXX": "g++-14",
+        "CC": "gcc-14"
       }
     },
     {
@@ -169,7 +190,7 @@
       "name": "coverage-linux",
       "binaryDir": "${sourceDir}/build/coverage",
       "inherits": [
-        "clang-18",
+        "clang-19",
         "dev-mode",
         "ci-linux"
       ],
@@ -215,7 +236,7 @@
       "inherits": [
         "vcpkg",
         "ci-linux",
-        "clang-18"
+        "clang-19"
       ]
     },
     {
@@ -225,7 +246,7 @@
         "sanitize-linux",
         "dev-mode",
         "vcpkg",
-        "clang-18"
+        "clang-19"
       ]
     },
     {
@@ -234,14 +255,14 @@
       "hidden": true
     },
     {
-      "name": "ci-ubuntu-clang-18",
+      "name": "ci-ubuntu-clang-19",
       "inherits": [
         "ci-build",
         "ci-linux",
         "clang-tidy",
         "vcpkg",
         "dev-mode",
-        "clang-18"
+        "clang-19"
       ]
     },
     {
@@ -258,13 +279,13 @@
       }
     },
     {
-      "name": "ci-ubuntu-gcc-13",
+      "name": "ci-ubuntu-gcc-14",
       "inherits": [
         "ci-build",
         "ci-linux",
         "vcpkg",
         "dev-mode",
-        "gcc-13"
+        "gcc-14"
       ]
     },
     {
@@ -282,7 +303,7 @@
         "ci-build",
         "ci-linux",
         "vcpkg",
-        "gcc-13"
+        "gcc-14"
       ]
     }
   ]

--- a/CMakeUserPresets.template.json
+++ b/CMakeUserPresets.template.json
@@ -2,8 +2,8 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 22,
-    "patch": 1
+    "minor": 30,
+    "patch": 0
   },
   "configurePresets": [
     {
@@ -25,7 +25,7 @@
       "inherits": [
         "dev-common",
         "ci-linux",
-        "clang-18"
+        "clang-19"
       ],
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
@@ -55,7 +55,7 @@
       "name": "dev-gcc",
       "binaryDir": "${sourceDir}/build/dev-gcc",
       "inherits": [
-        "gcc-13",
+        "gcc-14",
         "dev-linux"
       ]
     },

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A modern, low latency datadog stats library for c++
 
 ## Getting Started
 
-```cpp :file=./example/getting_started.cpp:line_start=2:line_end=-2
+```cpp :file=./example/getting_started.cpp:line_start=0:line_end=23
 #include "bark/bark.hpp"
 
 auto main() -> int

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.30)
 
 project(barkBenchmarks LANGUAGES CXX)
 

--- a/cmake-format.yaml
+++ b/cmake-format.yaml
@@ -1,222 +1,264 @@
 _help_parse: Options affecting listfile parsing
 parse:
   _help_additional_commands:
-  - Specify structure for custom cmake functions
+    - Specify structure for custom cmake functions
   additional_commands:
-    foo:
-      flags:
-      - BAR
-      - BAZ
+    generate_export_header:
       kwargs:
-        HEADERS: '*'
-        SOURCES: '*'
-        DEPENDS: '*'
+        BASE_NAME: "*"
+        EXPORT_FILE_NAME: "*"
+        CUSTOM_CONTENT_FROM_VARIABLE: "*"
+    target_link_libraries:
+      pargs:
+        nargs: 1
+      kwargs:
+        PRIVATE:
+          pargs:
+            nargs: "*"
+            sortable: true
+        PUBLIC:
+          pargs:
+            nargs: "*"
+            sortable: true
+        INTERFACE:
+          pargs:
+            nargs: "*"
+            sortable: true
+    target_sources:
+      pargs:
+        nargs: 1
+      kwargs:
+        PRIVATE:
+          pargs:
+            nargs: "*"
+            sortable: true
+        PUBLIC:
+          pargs:
+            nargs: "*"
+            sortable: true
+        INTERFACE:
+          pargs:
+            nargs: "*"
+            sortable: true
+        FILE_SET: 
+          pargs:
+            nargs: 1
+          kwargs:
+            TYPE: 1
+            BASE_DIRS:
+              pargs:
+                nargs: "+"
+                sortable: true
+            FILES:
+              pargs:
+                nargs: "+"
+                sortable: true
   _help_override_spec:
-  - Override configurations per-command where available
+    - Override configurations per-command where available
   override_spec: {}
   _help_vartags:
-  - Specify variable tags.
+    - Specify variable tags.
   vartags: []
   _help_proptags:
-  - Specify property tags.
+    - Specify property tags.
   proptags: []
 _help_format: Options affecting formatting.
 format:
   _help_disable:
-  - Disable formatting entirely, making cmake-format a no-op
+    - Disable formatting entirely, making cmake-format a no-op
   disable: false
   _help_line_width:
-  - How wide to allow formatted cmake files
+    - How wide to allow formatted cmake files
   line_width: 160
   _help_tab_size:
-  - How many spaces to tab for indent
+    - How many spaces to tab for indent
   tab_size: 4
   _help_use_tabchars:
-  - If true, lines are indented using tab characters (utf-8
-  - 0x09) instead of <tab_size> space characters (utf-8 0x20).
-  - In cases where the layout would require a fractional tab
-  - character, the behavior of the  fractional indentation is
-  - governed by <fractional_tab_policy>
+    - If true, lines are indented using tab characters (utf-8
+    - 0x09) instead of <tab_size> space characters (utf-8 0x20).
+    - In cases where the layout would require a fractional tab
+    - character, the behavior of the  fractional indentation is
+    - governed by <fractional_tab_policy>
   use_tabchars: false
   _help_fractional_tab_policy:
-  - If <use_tabchars> is True, then the value of this variable
-  - indicates how fractional indentions are handled during
-  - whitespace replacement. If set to 'use-space', fractional
-  - indentation is left as spaces (utf-8 0x20). If set to
-  - '`round-up` fractional indentation is replaced with a single'
-  - tab character (utf-8 0x09) effectively shifting the column
-  - to the next tabstop
+    - If <use_tabchars> is True, then the value of this variable
+    - indicates how fractional indentions are handled during
+    - whitespace replacement. If set to 'use-space', fractional
+    - indentation is left as spaces (utf-8 0x20). If set to
+    - "`round-up` fractional indentation is replaced with a single"
+    - tab character (utf-8 0x09) effectively shifting the column
+    - to the next tabstop
   fractional_tab_policy: use-space
   _help_max_subgroups_hwrap:
-  - If an argument group contains more than this many sub-groups
-  - (parg or kwarg groups) then force it to a vertical layout.
+    - If an argument group contains more than this many sub-groups
+    - (parg or kwarg groups) then force it to a vertical layout.
   max_subgroups_hwrap: 2
   _help_max_pargs_hwrap:
-  - If a positional argument group contains more than this many
-  - arguments, then force it to a vertical layout.
+    - If a positional argument group contains more than this many
+    - arguments, then force it to a vertical layout.
   max_pargs_hwrap: 3
   _help_max_rows_cmdline:
-  - If a cmdline positional group consumes more than this many
-  - lines without nesting, then invalidate the layout (and nest)
+    - If a cmdline positional group consumes more than this many
+    - lines without nesting, then invalidate the layout (and nest)
   max_rows_cmdline: 2
   _help_separate_ctrl_name_with_space:
-  - If true, separate flow control names from their parentheses
-  - with a space
+    - If true, separate flow control names from their parentheses
+    - with a space
   separate_ctrl_name_with_space: true
   _help_separate_fn_name_with_space:
-  - If true, separate function names from parentheses with a
-  - space
+    - If true, separate function names from parentheses with a
+    - space
   separate_fn_name_with_space: false
   _help_dangle_parens:
-  - If a statement is wrapped to more than one line, than dangle
-  - the closing parenthesis on its own line.
+    - If a statement is wrapped to more than one line, than dangle
+    - the closing parenthesis on its own line.
   dangle_parens: true
   _help_dangle_align:
-  - If the trailing parenthesis must be 'dangled' on its on
-  - 'line, then align it to this reference: `prefix`: the start'
-  - 'of the statement,  `prefix-indent`: the start of the'
-  - 'statement, plus one indentation  level, `child`: align to'
-  - the column of the arguments
+    - If the trailing parenthesis must be 'dangled' on its on
+    - "line, then align it to this reference: `prefix`: the start"
+    - "of the statement,  `prefix-indent`: the start of the"
+    - "statement, plus one indentation  level, `child`: align to"
+    - the column of the arguments
   dangle_align: prefix
   _help_min_prefix_chars:
-  - If the statement spelling length (including space and
-  - parenthesis) is smaller than this amount, then force reject
-  - nested layouts.
+    - If the statement spelling length (including space and
+    - parenthesis) is smaller than this amount, then force reject
+    - nested layouts.
   min_prefix_chars: 4
   _help_max_prefix_chars:
-  - If the statement spelling length (including space and
-  - parenthesis) is larger than the tab width by more than this
-  - amount, then force reject un-nested layouts.
+    - If the statement spelling length (including space and
+    - parenthesis) is larger than the tab width by more than this
+    - amount, then force reject un-nested layouts.
   max_prefix_chars: 10
   _help_max_lines_hwrap:
-  - If a candidate layout is wrapped horizontally but it exceeds
-  - this many lines, then reject the layout.
+    - If a candidate layout is wrapped horizontally but it exceeds
+    - this many lines, then reject the layout.
   max_lines_hwrap: 2
   _help_line_ending:
-  - What style line endings to use in the output.
+    - What style line endings to use in the output.
   line_ending: unix
   _help_command_case:
-  - Format command names consistently as 'lower' or 'upper' case
+    - Format command names consistently as 'lower' or 'upper' case
   command_case: canonical
   _help_keyword_case:
-  - Format keywords consistently as 'lower' or 'upper' case
+    - Format keywords consistently as 'lower' or 'upper' case
   keyword_case: unchanged
   _help_always_wrap:
-  - A list of command names which should always be wrapped
+    - A list of command names which should always be wrapped
   always_wrap: []
   _help_enable_sort:
-  - If true, the argument lists which are known to be sortable
-  - will be sorted lexicographicall
+    - If true, the argument lists which are known to be sortable
+    - will be sorted lexicographicall
   enable_sort: true
   _help_autosort:
-  - If true, the parsers may infer whether or not an argument
-  - list is sortable (without annotation).
+    - If true, the parsers may infer whether or not an argument
+    - list is sortable (without annotation).
   autosort: true
   _help_require_valid_layout:
-  - By default, if cmake-format cannot successfully fit
-  - everything into the desired linewidth it will apply the
-  - last, most agressive attempt that it made. If this flag is
-  - True, however, cmake-format will print error, exit with non-
-  - zero status code, and write-out nothing
+    - By default, if cmake-format cannot successfully fit
+    - everything into the desired linewidth it will apply the
+    - last, most agressive attempt that it made. If this flag is
+    - True, however, cmake-format will print error, exit with non-
+    - zero status code, and write-out nothing
   require_valid_layout: false
   _help_layout_passes:
-  - A dictionary mapping layout nodes to a list of wrap
-  - decisions. See the documentation for more information.
+    - A dictionary mapping layout nodes to a list of wrap
+    - decisions. See the documentation for more information.
   layout_passes: {}
 _help_markup: Options affecting comment reflow and formatting.
 markup:
   _help_bullet_char:
-  - What character to use for bulleted lists
-  bullet_char: '*'
+    - What character to use for bulleted lists
+  bullet_char: "*"
   _help_enum_char:
-  - What character to use as punctuation after numerals in an
-  - enumerated list
+    - What character to use as punctuation after numerals in an
+    - enumerated list
   enum_char: .
   _help_first_comment_is_literal:
-  - If comment markup is enabled, don't reflow the first comment
-  - block in each listfile. Use this to preserve formatting of
-  - your copyright/license statements.
+    - If comment markup is enabled, don't reflow the first comment
+    - block in each listfile. Use this to preserve formatting of
+    - your copyright/license statements.
   first_comment_is_literal: false
   _help_literal_comment_pattern:
-  - If comment markup is enabled, don't reflow any comment block
-  - which matches this (regex) pattern. Default is `None`
-  - (disabled).
+    - If comment markup is enabled, don't reflow any comment block
+    - which matches this (regex) pattern. Default is `None`
+    - (disabled).
   literal_comment_pattern: null
   _help_fence_pattern:
-  - Regular expression to match preformat fences in comments
-  - default= ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    - Regular expression to match preformat fences in comments
+    - default= ``r'^\s*([`~]{3}[`~]*)(.*)$'``
   fence_pattern: ^\s*([`~]{3}[`~]*)(.*)$
   _help_ruler_pattern:
-  - Regular expression to match rulers in comments default=
-  - '``r''^\s*[^\w\s]{3}.*[^\w\s]{3}$''``'
+    - Regular expression to match rulers in comments default=
+    - '``r''^\s*[^\w\s]{3}.*[^\w\s]{3}$''``'
   ruler_pattern: ^\s*[^\w\s]{3}.*[^\w\s]{3}$
   _help_explicit_trailing_pattern:
-  - If a comment line matches starts with this pattern then it
-  - is explicitly a trailing comment for the preceeding
-  - argument. Default is '#<'
-  explicit_trailing_pattern: '#<'
+    - If a comment line matches starts with this pattern then it
+    - is explicitly a trailing comment for the preceeding
+    - argument. Default is '#<'
+  explicit_trailing_pattern: "#<"
   _help_hashruler_min_length:
-  - If a comment line starts with at least this many consecutive
-  - hash characters, then don't lstrip() them off. This allows
-  - for lazy hash rulers where the first hash char is not
-  - separated by space
+    - If a comment line starts with at least this many consecutive
+    - hash characters, then don't lstrip() them off. This allows
+    - for lazy hash rulers where the first hash char is not
+    - separated by space
   hashruler_min_length: 10
   _help_canonicalize_hashrulers:
-  - If true, then insert a space between the first hash char and
-  - remaining hash chars in a hash ruler, and normalize its
-  - length to fill the column
+    - If true, then insert a space between the first hash char and
+    - remaining hash chars in a hash ruler, and normalize its
+    - length to fill the column
   canonicalize_hashrulers: true
   _help_enable_markup:
-  - enable comment markup parsing and reflow
+    - enable comment markup parsing and reflow
   enable_markup: true
 _help_lint: Options affecting the linter
 lint:
   _help_disabled_codes:
-  - a list of lint codes to disable
+    - a list of lint codes to disable
   disabled_codes: []
   _help_function_pattern:
-  - regular expression pattern describing valid function names
-  function_pattern: '[0-9a-z_]+'
+    - regular expression pattern describing valid function names
+  function_pattern: "[0-9a-z_]+"
   _help_macro_pattern:
-  - regular expression pattern describing valid macro names
-  macro_pattern: '[0-9A-Z_]+'
+    - regular expression pattern describing valid macro names
+  macro_pattern: "[0-9A-Z_]+"
   _help_global_var_pattern:
-  - regular expression pattern describing valid names for
-  - variables with global (cache) scope
-  global_var_pattern: '[A-Z][0-9A-Z_]+'
+    - regular expression pattern describing valid names for
+    - variables with global (cache) scope
+  global_var_pattern: "[A-Z][0-9A-Z_]+"
   _help_internal_var_pattern:
-  - regular expression pattern describing valid names for
-  - variables with global scope (but internal semantic)
+    - regular expression pattern describing valid names for
+    - variables with global scope (but internal semantic)
   internal_var_pattern: _[A-Z][0-9A-Z_]+
   _help_local_var_pattern:
-  - regular expression pattern describing valid names for
-  - variables with local scope
-  local_var_pattern: '[a-z][a-z0-9_]+'
+    - regular expression pattern describing valid names for
+    - variables with local scope
+  local_var_pattern: "[a-z][a-z0-9_]+"
   _help_private_var_pattern:
-  - regular expression pattern describing valid names for
-  - privatedirectory variables
+    - regular expression pattern describing valid names for
+    - privatedirectory variables
   private_var_pattern: _[0-9a-z_]+
   _help_public_var_pattern:
-  - regular expression pattern describing valid names for public
-  - directory variables
-  public_var_pattern: '[A-Z][0-9A-Z_]+'
+    - regular expression pattern describing valid names for public
+    - directory variables
+  public_var_pattern: "[A-Z][0-9A-Z_]+"
   _help_argument_var_pattern:
-  - regular expression pattern describing valid names for
-  - function/macro arguments and loop variables.
-  argument_var_pattern: '[a-z][a-z0-9_]+'
+    - regular expression pattern describing valid names for
+    - function/macro arguments and loop variables.
+  argument_var_pattern: "[a-z][a-z0-9_]+"
   _help_keyword_pattern:
-  - regular expression pattern describing valid names for
-  - keywords used in functions or macros
-  keyword_pattern: '[A-Z][0-9A-Z_]+'
+    - regular expression pattern describing valid names for
+    - keywords used in functions or macros
+  keyword_pattern: "[A-Z][0-9A-Z_]+"
   _help_max_conditionals_custom_parser:
-  - In the heuristic for C0201, how many conditionals to match
-  - within a loop in before considering the loop a parser.
+    - In the heuristic for C0201, how many conditionals to match
+    - within a loop in before considering the loop a parser.
   max_conditionals_custom_parser: 2
   _help_min_statement_spacing:
-  - Require at least this many newlines between statements
+    - Require at least this many newlines between statements
   min_statement_spacing: 1
   _help_max_statement_spacing:
-  - Require no more than this many newlines between statements
+    - Require no more than this many newlines between statements
   max_statement_spacing: 2
   max_returns: 6
   max_branches: 12
@@ -226,20 +268,20 @@ lint:
 _help_encode: Options affecting file encoding
 encode:
   _help_emit_byteorder_mark:
-  - If true, emit the unicode byte-order mark (BOM) at the start
-  - of the file
+    - If true, emit the unicode byte-order mark (BOM) at the start
+    - of the file
   emit_byteorder_mark: false
   _help_input_encoding:
-  - Specify the encoding of the input file. Defaults to utf-8
+    - Specify the encoding of the input file. Defaults to utf-8
   input_encoding: utf-8
   _help_output_encoding:
-  - Specify the encoding of the output file. Defaults to utf-8.
-  - Note that cmake only claims to support utf-8 so be careful
-  - when using anything else
+    - Specify the encoding of the output file. Defaults to utf-8.
+    - Note that cmake only claims to support utf-8 so be careful
+    - when using anything else
   output_encoding: utf-8
 _help_misc: Miscellaneous configurations options.
 misc:
   _help_per_command:
-  - A dictionary containing any per-command configuration
-  - overrides. Currently only `command_case` is supported.
+    - A dictionary containing any per-command configuration
+    - overrides. Currently only `command_case` is supported.
   per_command: {}

--- a/cmake/install-rules.cmake
+++ b/cmake/install-rules.cmake
@@ -29,6 +29,7 @@ install(
             COMPONENT bark_Development
     INCLUDES #
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+    FILE_SET HEADERS
 )
 
 write_basic_package_version_file("${package}ConfigVersion.cmake" COMPATIBILITY SameMajorVersion)

--- a/cmake/lint.cmake
+++ b/cmake/lint.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.30)
 
 macro (default name)
     if (NOT DEFINED "${name}")

--- a/cmake/spell.cmake
+++ b/cmake/spell.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.30)
 
 macro (default name)
     if (NOT DEFINED "${name}")

--- a/example/.clang-tidy
+++ b/example/.clang-tidy
@@ -1,0 +1,7 @@
+---
+InheritParentConfig: "true"
+Checks: "\
+     -cppcoreguidelines-avoid-magic-numbers\
+    ,-readability-magic-numbers\
+    ,-google-build-using-namespace\
+    "

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.27)
+cmake_minimum_required(VERSION 3.30)
 
 project(barkExamples CXX)
 

--- a/example/getting_started.cpp
+++ b/example/getting_started.cpp
@@ -1,5 +1,3 @@
-// NOLINTBEGIN(misc-include-cleaner)
-
 #include "bark/bark.hpp"
 
 auto main() -> int
@@ -23,5 +21,3 @@ auto main() -> int
 
     return 0;
 }
-
-// NOLINTEND(misc-include-cleaner)

--- a/include/bark/asio_io_context_wrapper.hpp
+++ b/include/bark/asio_io_context_wrapper.hpp
@@ -7,7 +7,7 @@
 #    pragma GCC diagnostic ignored "-Wnull-dereference"
 #endif
 
-#include <asio/io_context.hpp>
+#include <asio/io_context.hpp>  // IWYU pragma: export
 
 #if BARK_GCC_VERSION > 0
 #    pragma GCC diagnostic pop

--- a/include/bark/bark.hpp
+++ b/include/bark/bark.hpp
@@ -5,20 +5,18 @@
  *
  */
 
-// NOLINTBEGIN(misc-include-cleaner)
-#include "bark/asio_client.hpp"
-#include "bark/client.hpp"
-#include "bark/count.hpp"
-#include "bark/datagram.hpp"
-#include "bark/event.hpp"
-#include "bark/gauge.hpp"
-#include "bark/histogram.hpp"
-#include "bark/i_datadog_client.hpp"
-#include "bark/mpmc_client.hpp"
-#include "bark/noop_client.hpp"
-#include "bark/number_of_io_threads.hpp"
-#include "bark/sample_rate.hpp"
-#include "bark/spsc_client.hpp"
-#include "bark/tags.hpp"
-#include "bark/udp_client.hpp"
-// NOLINTEND(misc-include-cleaner)
+#include "bark/asio_client.hpp"           // IWYU pragma: export
+#include "bark/client.hpp"                // IWYU pragma: export
+#include "bark/count.hpp"                 // IWYU pragma: export
+#include "bark/datagram.hpp"              // IWYU pragma: export
+#include "bark/event.hpp"                 // IWYU pragma: export
+#include "bark/gauge.hpp"                 // IWYU pragma: export
+#include "bark/histogram.hpp"             // IWYU pragma: export
+#include "bark/i_datadog_client.hpp"      // IWYU pragma: export
+#include "bark/mpmc_client.hpp"           // IWYU pragma: export
+#include "bark/noop_client.hpp"           // IWYU pragma: export
+#include "bark/number_of_io_threads.hpp"  // IWYU pragma: export
+#include "bark/sample_rate.hpp"           // IWYU pragma: export
+#include "bark/spsc_client.hpp"           // IWYU pragma: export
+#include "bark/tags.hpp"                  // IWYU pragma: export
+#include "bark/udp_client.hpp"            // IWYU pragma: export

--- a/source/asio_client.cpp
+++ b/source/asio_client.cpp
@@ -19,7 +19,7 @@
 #include <asio/ip/udp.hpp>
 #include <asio/post.hpp>
 #include <fmt/base.h>
-#include <fmt/std.h>
+#include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
 #include "bark/asio_client.hpp"
 #include "bark/datagram.hpp"

--- a/source/udp_client.cpp
+++ b/source/udp_client.cpp
@@ -15,7 +15,7 @@
 #include <asio/buffer.hpp>
 #include <asio/ip/udp.hpp>
 #include <fmt/base.h>
-#include <fmt/std.h>
+#include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
 namespace bark
 {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(
     source/tags_tests.cpp
     source/udp_client_tests.cpp
 )
-target_link_libraries(bark_test PRIVATE twig::bark doctest::doctest)
+target_link_libraries(bark_test PRIVATE doctest::doctest twig::bark)
 target_compile_features(bark_test PRIVATE cxx_std_20)
 
 add_test(NAME bark_test COMMAND bark_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.30)
 
 project(barkTests LANGUAGES CXX)
 

--- a/test/source/details/udp_server.cpp
+++ b/test/source/details/udp_server.cpp
@@ -13,7 +13,7 @@
 #include <asio/buffer.hpp>
 #include <asio/ip/udp.hpp>
 #include <fmt/base.h>
-#include <fmt/std.h>
+#include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
 #include "./udp_server.hpp"
 

--- a/tools/check_include_what_you_use.sh
+++ b/tools/check_include_what_you_use.sh
@@ -3,12 +3,12 @@
 # find recursively which folder starting from build, contains the compile_commands.json file
 export BUILD_FOLDER=$(find build -name compile_commands.json -printf "%h\n" | head -n 1)
 
-git diff --diff-filter=d --name-only origin/main | grep -E "\.hpp$" | xargs -r -t -n 1 -P 8 -- clang-tidy-18 --fix --checks="-*,misc-include-cleaner" -p $BUILD_FOLDER
-git diff --diff-filter=d --name-only origin/main | grep -E "\.cpp$" | xargs -r -t -n 1 -P 8 -- clang-tidy-18 --fix --checks="-*,misc-include-cleaner" -p $BUILD_FOLDER
+git diff --diff-filter=d --name-only origin/main | grep -E "\.hpp$" | xargs -r -t -n 1 -P 8 -- clang-tidy-19 --fix --checks="-*,misc-include-cleaner" -p $BUILD_FOLDER
+git diff --diff-filter=d --name-only origin/main | grep -E "\.cpp$" | xargs -r -t -n 1 -P 8 -- clang-tidy-19 --fix --checks="-*,misc-include-cleaner" -p $BUILD_FOLDER
 
 # Format after fixing
-git diff --diff-filter=d --name-only origin/main | grep -E "\.hpp$" | xargs -I{} -t -n 1 -P 8 sh -c 'cmake -D FIX=YES -D PATTERNS="{}" -D FORMAT_COMMAND=clang-format-18 -P cmake/lint.cmake'
-git diff --diff-filter=d --name-only origin/main | grep -E "\.cpp$" | xargs -I{} -t -n 1 -P 8 sh -c 'cmake -D FIX=YES -D PATTERNS="{}" -D FORMAT_COMMAND=clang-format-18 -P cmake/lint.cmake'
+git diff --diff-filter=d --name-only origin/main | grep -E "\.hpp$" | xargs -I{} -t -n 1 -P 8 sh -c 'cmake -D FIX=YES -D PATTERNS="{}" -D FORMAT_COMMAND=clang-format-19 -P cmake/lint.cmake'
+git diff --diff-filter=d --name-only origin/main | grep -E "\.cpp$" | xargs -I{} -t -n 1 -P 8 sh -c 'cmake -D FIX=YES -D PATTERNS="{}" -D FORMAT_COMMAND=clang-format-19 -P cmake/lint.cmake'
 
-echo "Checking diff after clang-tidy-18"
+echo "Checking diff after clang-tidy-19"
 git --no-pager diff --quiet || exit 1

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,5 +17,5 @@
       ]
     }
   },
-  "builtin-baseline": "c82f74667287d3dc386bce81e44964370c91a289"
+  "builtin-baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
 }


### PR DESCRIPTION
### Why 
C++ is a moving target.

Updated to clang-19 since clang-20 in c++23 mode has issues with the version of fmt that is available on vcpkg.
Updated to gcc-14 since gcc-15 is not easily available in the Ubuntu 24.04 apt repositories.
Still kept gcc-11, since that is what vcpkg will use.

I will update required CI actions, if approved.

### What was changed
- **Use IWYU pragmas over NOLINTs.**
- **Update toolchains. Use clang-19 and gcc-14 in dev and CI**
- **Use FILE_SET HEADERS. Update cmake-format configuration.**
- **Update vcpkg baseline.**
- **Version bump**