### PR TITLE
Allow input which is convertible to double in Gauge and Histogram

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.30)
 include(cmake/prelude.cmake)
 project(
     bark
-    VERSION 0.3.1
+    VERSION 0.4.0
     DESCRIPTION "Datadog Agent client for C++"
     HOMEPAGE_URL "https://github.com/twig-energy/bark"
     LANGUAGES CXX

--- a/include/bark/gauge.hpp
+++ b/include/bark/gauge.hpp
@@ -18,9 +18,9 @@ struct Gauge
     double value;
     Tags tags;
 
-    BARK_CONSTEXPR Gauge(std::string metric_, double value_) noexcept
+    BARK_CONSTEXPR Gauge(std::string metric_, auto value_) noexcept
         : metric(std::move(metric_))
-        , value(value_)
+        , value(static_cast<double>(value_))
     {
     }
 

--- a/include/bark/histogram.hpp
+++ b/include/bark/histogram.hpp
@@ -21,9 +21,9 @@ struct Histogram
     double sample_rate = 1.0;
     Tags tags;
 
-    BARK_CONSTEXPR Histogram(std::string metric_, double value_) noexcept
+    BARK_CONSTEXPR Histogram(std::string metric_, auto value_) noexcept
         : metric(std::move(metric_))
-        , value(value_)
+        , value(static_cast<double>(value_))
     {
     }
 

--- a/test/source/main.cpp
+++ b/test/source/main.cpp
@@ -1,15 +1,2 @@
-#include <string>
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 #include <doctest/doctest.h>
-
-namespace bark
-{
-
-// doctest::detail::g_cs->currentTest->m_name is only accessible in the compilation unit that has
-// DOCTEST_CONFIG_IMPLEMENT or DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN defined.
-auto current_test_name() -> std::string
-{
-    return doctest::detail::g_cs->currentTest->m_name;
-}
-
-}  // namespace bark


### PR DESCRIPTION
### Why 
To make the usage of the library more ergonomic.

### What was changed
- Changed constructors of Gauge and Histogram to receive any value and then static_cast it to double.