### PR TITLE
Add operator== to data structs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.30)
 include(cmake/prelude.cmake)
 project(
     bark
-    VERSION 0.4.0
+    VERSION 0.5.0
     DESCRIPTION "Datadog Agent client for C++"
     HOMEPAGE_URL "https://github.com/twig-energy/bark"
     LANGUAGES CXX

--- a/include/bark/count.hpp
+++ b/include/bark/count.hpp
@@ -45,6 +45,8 @@ struct Count
     }
 
     auto serialize(const Tags& global_tags) const -> std::string;
+
+    BARK_CONSTEXPR auto operator==(const Count&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/event.hpp
+++ b/include/bark/event.hpp
@@ -61,6 +61,8 @@ struct Event
     }
 
     auto serialize(const Tags& global_tags) const -> std::string;
+
+    BARK_CONSTEXPR auto operator==(const Event&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/gauge.hpp
+++ b/include/bark/gauge.hpp
@@ -31,6 +31,8 @@ struct Gauge
     }
 
     auto serialize(const Tags& global_tags) const -> std::string;
+
+    BARK_CONSTEXPR auto operator==(const Gauge&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/histogram.hpp
+++ b/include/bark/histogram.hpp
@@ -44,6 +44,8 @@ struct Histogram
     }
 
     auto serialize(const Tags& global_tags) const -> std::string;
+
+    BARK_CONSTEXPR auto operator==(const Histogram&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/number_of_io_threads.hpp
+++ b/include/bark/number_of_io_threads.hpp
@@ -2,12 +2,16 @@
 
 #include <cstddef>
 
+#include "feature_detection.hpp"
+
 namespace bark
 {
 
 struct NumberOfIOThreads
 {
     std::size_t value;
+
+    BARK_CONSTEXPR auto operator==(const NumberOfIOThreads&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/sample_rate.hpp
+++ b/include/bark/sample_rate.hpp
@@ -1,11 +1,15 @@
 #pragma once
 
+#include "feature_detection.hpp"
+
 namespace bark
 {
 
 struct SampleRate
 {
     double value;
+
+    BARK_CONSTEXPR auto operator==(const SampleRate&) const -> bool = default;
 };
 
 }  // namespace bark

--- a/include/bark/tags.hpp
+++ b/include/bark/tags.hpp
@@ -84,10 +84,12 @@ class Tags
         return Tags {std::move(tags_string)};
     }
 
-    constexpr auto str() const -> const std::string&
+    BARK_CONSTEXPR auto str() const -> const std::string&
     {
         return this->_tags;
     }
+
+    BARK_CONSTEXPR auto operator==(const Tags&) const -> bool = default;
 };
 
 inline const auto no_tags = Tags();


### PR DESCRIPTION
### Why 
It is quite cumbersome to make mock expectations on calls to the datadog client, because the metrics are not equatable.

This seeks to fix that.

### What was changed
* Added operator== to a bunch of data structs.
