### PR TITLE
Use boost-asio.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Spell check
         run: |
-          pip3 install codespell
+          pip3 install codespell --only-binary :all:
           cmake -P cmake/spell.cmake
 
       - name: Test version bumped

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
 
 env:
-  VCPKG_COMMIT: "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+  VCPKG_COMMIT: "f3e10653cc27d62a37a3763cd84b38bca07c6075"
 
 jobs:
   lint:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ include(cmake/dev-mode.cmake)
 
 # ---- Dependencies ----
 
-find_package(asio CONFIG REQUIRED)
+find_package(Boost CONFIG REQUIRED COMPONENTS asio)
 find_package(fmt REQUIRED)
 find_package(MPMCQueue CONFIG REQUIRED)
 find_package(SPSCQueue CONFIG REQUIRED)
@@ -91,7 +91,7 @@ target_compile_features(bark PUBLIC cxx_std_23)
 
 target_link_libraries(
     bark
-    PUBLIC asio::asio MPMCQueue::MPMCQueue SPSCQueue::SPSCQueue
+    PUBLIC Boost::asio MPMCQueue::MPMCQueue SPSCQueue::SPSCQueue
     PRIVATE fmt::fmt
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.30)
 include(cmake/prelude.cmake)
 project(
     bark
-    VERSION 0.5.0
+    VERSION 0.6.0
     DESCRIPTION "Datadog Agent client for C++"
     HOMEPAGE_URL "https://github.com/twig-energy/bark"
     LANGUAGES CXX

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We provide a number of Client implementations for different use cases:
 | `Client`     | None                                | The publishing thread only   | Sends metrics on the publishing thread         |
 | `SPSCClient` | Single Producer Single Consumer     | The publishing thread + 1    | Fixed queue size. Drops new messages when full |
 | `MPMCClient` | Multiple Producer Multiple Consumer | The publishing thread + 1    | Fixed queue size. Drops new messages when full |
-| `AsioClient` | `boost::asio::io_context`                  | The publishing thread + `N`  | `N` is supplied when creating the client       |
+| `AsioClient` | `boost::asio::io_context`           | The publishing thread + `N`  | `N` is supplied when creating the client       |
 | `NoOpClient` | None                                | (The publishing thread)/None | Useful for testing                             |
 
 All of these clients implement the `IDatadogClient` interface. You are not required to use it, but it is there to allow mocking and ease of use for those that need it.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We provide a number of Client implementations for different use cases:
 | `Client`     | None                                | The publishing thread only   | Sends metrics on the publishing thread         |
 | `SPSCClient` | Single Producer Single Consumer     | The publishing thread + 1    | Fixed queue size. Drops new messages when full |
 | `MPMCClient` | Multiple Producer Multiple Consumer | The publishing thread + 1    | Fixed queue size. Drops new messages when full |
-| `AsioClient` | `asio::io_context`                  | The publishing thread + `N`  | `N` is supplied when creating the client       |
+| `AsioClient` | `boost::asio::io_context`                  | The publishing thread + `N`  | `N` is supplied when creating the client       |
 | `NoOpClient` | None                                | (The publishing thread)/None | Useful for testing                             |
 
 All of these clients implement the `IDatadogClient` interface. You are not required to use it, but it is there to allow mocking and ease of use for those that need it.

--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
-find_dependency(asio)
+find_dependency(boost COMPONENTS asio)
 find_dependency(fmt)
 find_dependency(MPMCQueue)
 find_dependency(SPSCQueue)

--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,5 +1,5 @@
 include(CMakeFindDependencyMacro)
-find_dependency(boost COMPONENTS asio)
+find_dependency(Boost COMPONENTS asio)
 find_dependency(fmt)
 find_dependency(MPMCQueue)
 find_dependency(SPSCQueue)

--- a/include/bark/asio_client.hpp
+++ b/include/bark/asio_client.hpp
@@ -10,8 +10,8 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/executor_work_guard.hpp>
-#include <asio/ip/udp.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/ip/udp.hpp>
 
 #include "bark/datagram.hpp"
 #include "bark/i_datadog_client.hpp"
@@ -25,16 +25,16 @@ namespace bark
 class AsioClient final : public IDatadogClient
 {
     std::unique_ptr<Tags> _global_tags;
-    std::unique_ptr<asio::io_context> _io_context;
-    std::unique_ptr<asio::ip::udp::endpoint> _receiver_endpoint;
-    std::unique_ptr<asio::ip::udp::socket> _socket;
+    std::unique_ptr<boost::asio::io_context> _io_context;
+    std::unique_ptr<boost::asio::ip::udp::endpoint> _receiver_endpoint;
+    std::unique_ptr<boost::asio::ip::udp::socket> _socket;
     std::vector<std::jthread> _io_threads;
 
     // This is registered after the threads, since it's destruction will allow the worker threads to stop when no more
     // work is in the queue.
-    std::unique_ptr<asio::executor_work_guard<asio::io_context::executor_type>> _work_guard =
-        std::make_unique<asio::executor_work_guard<asio::io_context::executor_type>>(
-            asio::make_work_guard(*this->_io_context));
+    std::unique_ptr<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>> _work_guard =
+        std::make_unique<boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
+            boost::asio::make_work_guard(*this->_io_context));
 
   public:
     AsioClient(std::string_view host, uint16_t port, NumberOfIOThreads num_io_threads, Tags global_tags = no_tags);

--- a/include/bark/asio_io_context_wrapper.hpp
+++ b/include/bark/asio_io_context_wrapper.hpp
@@ -7,7 +7,7 @@
 #    pragma GCC diagnostic ignored "-Wnull-dereference"
 #endif
 
-#include <asio/io_context.hpp>  // IWYU pragma: export
+#include <boost/asio/io_context.hpp>  // IWYU pragma: export
 
 #if BARK_GCC_VERSION > 0
 #    pragma GCC diagnostic pop

--- a/include/bark/udp_client.hpp
+++ b/include/bark/udp_client.hpp
@@ -8,7 +8,7 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/ip/udp.hpp>
+#include <boost/asio/ip/udp.hpp>
 
 namespace bark
 {
@@ -17,9 +17,9 @@ constexpr static const uint16_t dogstatsd_udp_port = 8125;
 
 class UDPClient
 {
-    std::unique_ptr<asio::io_context> _io_context;
-    std::unique_ptr<asio::ip::udp::endpoint> _receiver_endpoint;
-    std::unique_ptr<asio::ip::udp::socket> _socket;
+    std::unique_ptr<boost::asio::io_context> _io_context;
+    std::unique_ptr<boost::asio::ip::udp::endpoint> _receiver_endpoint;
+    std::unique_ptr<boost::asio::ip::udp::socket> _socket;
 
   public:
     UDPClient(std::string_view host, uint16_t port);

--- a/source/asio_client.cpp
+++ b/source/asio_client.cpp
@@ -15,9 +15,9 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/buffer.hpp>
-#include <asio/ip/udp.hpp>
-#include <asio/post.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/ip/udp.hpp>
+#include <boost/asio/post.hpp>
 #include <fmt/base.h>
 #include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
@@ -31,18 +31,18 @@ namespace bark
 
 AsioClient::AsioClient(std::string_view host, uint16_t port, NumberOfIOThreads num_io_threads, Tags global_tags)
     : _global_tags(std::make_unique<Tags>(std::move(global_tags)))
-    , _io_context(std::make_unique<asio::io_context>(static_cast<int>(num_io_threads.value)))
-    , _receiver_endpoint(
-          std::make_unique<asio::ip::udp::endpoint>(*asio::ip::udp::resolver(*this->_io_context)
-                                                         .resolve(asio::ip::udp::v4(), host, std::to_string(port))
-                                                         .begin()))
-    , _socket(std::make_unique<asio::ip::udp::socket>(*this->_io_context))
+    , _io_context(std::make_unique<boost::asio::io_context>(static_cast<int>(num_io_threads.value)))
+    , _receiver_endpoint(std::make_unique<boost::asio::ip::udp::endpoint>(
+          *boost::asio::ip::udp::resolver(*this->_io_context)
+               .resolve(boost::asio::ip::udp::v4(), host, std::to_string(port))
+               .begin()))
+    , _socket(std::make_unique<boost::asio::ip::udp::socket>(*this->_io_context))
 {
     if (num_io_threads.value == 0) {
         throw std::invalid_argument("Cannot have 0 IO threads on AsioClient");
     }
 
-    this->_socket->open(asio::ip::udp::v4());
+    this->_socket->open(boost::asio::ip::udp::v4());
 
     this->_io_threads.reserve(num_io_threads.value);
     for (auto i = 0ULL; i < num_io_threads.value; i++) {
@@ -63,7 +63,7 @@ auto AsioClient::send(const Datagram& datagram) -> void
 
 auto AsioClient::send(Datagram&& datagram) -> void
 {
-    asio::post(  //
+    boost::asio::post(  //
         *this->_io_context,
         [global_tags_ptr = this->_global_tags.get(),
          socket_ptr = this->_socket.get(),
@@ -74,7 +74,7 @@ auto AsioClient::send(Datagram&& datagram) -> void
                                          { return serializable_datagram.serialize(*global_tags_ptr); },
                                          message);
 
-            auto buffer = asio::buffer(serialized);
+            auto buffer = boost::asio::buffer(serialized);
 
             socket_ptr->async_send_to(  //
                 buffer,

--- a/source/udp_client.cpp
+++ b/source/udp_client.cpp
@@ -5,15 +5,14 @@
 #include <source_location>
 #include <string>
 #include <string_view>
-#include <system_error>
 
 #include "bark/udp_client.hpp"
 
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/buffer.hpp>
-#include <asio/ip/udp.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <fmt/base.h>
 #include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
@@ -21,20 +20,20 @@ namespace bark
 {
 
 UDPClient::UDPClient(std::string_view host, uint16_t port)
-    : _io_context(std::make_unique<asio::io_context>())
-    , _receiver_endpoint(
-          std::make_unique<asio::ip::udp::endpoint>(*asio::ip::udp::resolver(*this->_io_context)
-                                                         .resolve(asio::ip::udp::v4(), host, std::to_string(port))
-                                                         .begin()))
-    , _socket(std::make_unique<asio::ip::udp::socket>(*this->_io_context))
+    : _io_context(std::make_unique<boost::asio::io_context>())
+    , _receiver_endpoint(std::make_unique<boost::asio::ip::udp::endpoint>(
+          *boost::asio::ip::udp::resolver(*this->_io_context)
+               .resolve(boost::asio::ip::udp::v4(), host, std::to_string(port))
+               .begin()))
+    , _socket(std::make_unique<boost::asio::ip::udp::socket>(*this->_io_context))
 {
-    this->_socket->open(asio::ip::udp::v4());
+    this->_socket->open(boost::asio::ip::udp::v4());
 }
 
 auto UDPClient::send(std::string_view msg) -> bool
 {
-    auto error = std::error_code {};
-    auto bytes_sent = this->_socket->send_to(asio::buffer(msg), *this->_receiver_endpoint, 0, error);
+    auto error = boost::system::error_code {};
+    auto bytes_sent = this->_socket->send_to(boost::asio::buffer(msg), *this->_receiver_endpoint, 0, error);
     if (error) [[unlikely]] {
         fmt::println(stderr, "Failed at sending {}. {}", error.message(), std::source_location::current());
     }

--- a/test/source/details/raii_async_context.hpp
+++ b/test/source/details/raii_async_context.hpp
@@ -7,7 +7,7 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/io_service.hpp>
+#include <boost/asio/executor_work_guard.hpp>
 
 #include "./udp_server.hpp"
 
@@ -16,7 +16,7 @@ namespace bark
 
 class RAIIAsyncContext
 {
-    asio::io_context _io_context;
+    boost::asio::io_context _io_context;
     std::jthread _runner;
 
   public:
@@ -32,7 +32,7 @@ class RAIIAsyncContext
             // at the io_context.run() call when the constructor is completed.
             [this, &server_creator_func, &is_initialized, &cond_var]
             {
-                const auto work = asio::io_service::work(this->_io_context);
+                const auto work = boost::asio::make_work_guard(this->_io_context);
                 auto server = server_creator_func(this->_io_context);
                 is_initialized = true;
                 cond_var.notify_one();  // now we can let the main thread continue
@@ -64,7 +64,7 @@ class RAIIAsyncContext
 template<typename ReceiveCallbackT>
 auto make_local_udp_server(uint16_t port, ReceiveCallbackT callback)
 {
-    return RAIIAsyncContext([&](asio::io_context& io_context)
+    return RAIIAsyncContext([&](boost::asio::io_context& io_context)
                             { return UDPServer(io_context, port, std::move(callback), 512); });
 }
 

--- a/test/source/details/udp_server.cpp
+++ b/test/source/details/udp_server.cpp
@@ -10,8 +10,8 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/buffer.hpp>
-#include <asio/ip/udp.hpp>
+#include <boost/asio/buffer.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <fmt/base.h>
 #include <fmt/std.h>  // IWYU pragma: keep - formatting of std::source_location
 
@@ -20,11 +20,11 @@
 namespace bark
 {
 
-UDPServer::UDPServer(asio::io_context& io_context,
+UDPServer::UDPServer(boost::asio::io_context& io_context,
                      int32_t port,
                      std::function<void(std::string_view)> receive_msg_callback,
                      size_t buffer_size)
-    : _socket(io_context, asio::ip::udp::endpoint(asio::ip::udp::v4(), static_cast<uint16_t>(port)))
+    : _socket(io_context, boost::asio::ip::udp::endpoint(boost::asio::ip::udp::v4(), static_cast<uint16_t>(port)))
     , _receive_msg_callback(std::move(receive_msg_callback))
     , _recv_buffer(buffer_size)
 {
@@ -33,7 +33,7 @@ UDPServer::UDPServer(asio::io_context& io_context,
 
 auto UDPServer::start_receive() -> void
 {
-    this->_socket.async_receive_from(asio::buffer(_recv_buffer),
+    this->_socket.async_receive_from(boost::asio::buffer(_recv_buffer),
                                      this->_latest_senders_endpoint,
                                      [this](const std::error_code& error, std::size_t bytes_transferred)
                                      { handle_receive(error, bytes_transferred); });

--- a/test/source/details/udp_server.hpp
+++ b/test/source/details/udp_server.hpp
@@ -9,7 +9,7 @@
 #include "bark/asio_io_context_wrapper.hpp"
 // ^ must be before asio includes, as it protects against gcc warnings
 
-#include <asio/ip/udp.hpp>
+#include <boost/asio/ip/udp.hpp>
 #include <fmt/core.h>
 
 namespace bark
@@ -17,13 +17,13 @@ namespace bark
 
 class UDPServer
 {
-    asio::ip::udp::socket _socket;
+    boost::asio::ip::udp::socket _socket;
     std::function<void(std::string_view)> _receive_msg_callback;
     std::vector<char> _recv_buffer;
-    asio::ip::udp::endpoint _latest_senders_endpoint;
+    boost::asio::ip::udp::endpoint _latest_senders_endpoint;
 
   public:
-    UDPServer(asio::io_context& io_context,
+    UDPServer(boost::asio::io_context& io_context,
               int32_t port,
               std::function<void(std::string_view)> receive_msg_callback,
               size_t buffer_size);

--- a/tools/check_install_packages_match.py
+++ b/tools/check_install_packages_match.py
@@ -4,6 +4,28 @@ These are used by downstream dependencies and therefore helps users install the 
 """
 
 
+def extract_components(
+    dependency_line: str, dependecy_to_components: dict[str, list[str]]
+) -> None:
+    words = dependency_line[
+        dependency_line.find("(") + 1 : dependency_line.rfind(")")
+    ].split(" ")
+    keywords = ["REQUIRED", "CONFIG"]
+    dependency = words[0]
+    in_component_list = False
+    for word in words[1:]:
+        word = word.strip()
+        if word == "COMPONENTS":
+            in_component_list = True
+            continue
+
+        if in_component_list:
+            if word in keywords:
+                break
+
+            dependecy_to_components[dependency].append(word)
+
+
 # %%
 def main() -> None:
     """
@@ -12,11 +34,28 @@ def main() -> None:
     dependency_str_lines: list[str] = []
 
     with open("CMakeLists.txt", "r", encoding="utf-8") as f:
+        current_find_package = ""
         for line in f:
+            line = line.strip()
             if line.startswith("find_package("):
-                dependency_str_lines.append(line)
+                if line.endswith(")"):
+                    dependency_str_lines.append(line)
+                else:
+                    current_find_package = line
+            elif current_find_package != "":
+                if current_find_package.endswith("(") or line.startswith(")"):
+                    current_find_package += line
+                else:
+                    current_find_package += " " + line
+
+                if line.endswith(")"):
+                    dependency_str_lines.append(current_find_package)
+                    current_find_package = ""
 
     dependencies = [line.split("(")[1].split(" ")[0] for line in dependency_str_lines]
+    dependency_components = {x: [] for x in dependencies}
+    for dependency_line in dependency_str_lines:
+        extract_components(dependency_line, dependency_components)
 
     install_dependency_str_lines = []
     with open("cmake/install-config.cmake", "r", encoding="utf-8") as f:
@@ -25,13 +64,23 @@ def main() -> None:
                 install_dependency_str_lines.append(line)
 
     install_dependencies = [
-        line.split("(")[1].split(")")[0] for line in install_dependency_str_lines
+        line.split("(")[1].split(")")[0].split(" ")[0]
+        for line in install_dependency_str_lines
     ]
+    install_dependency_components = {x: [] for x in install_dependencies}
+    for dependency_line in install_dependency_str_lines:
+        extract_components(dependency_line, install_dependency_components)
 
     assert set(install_dependencies) == set(dependencies), (
         f"Dependencies in find_package and install-config.cmake do not match.\n"
         f"find_package: {dependencies}\n"
         f"install-config.cmake: {install_dependencies}"
+    )
+
+    assert install_dependency_components == dependency_components, (
+        f"Component Dependencies in find_package and install-config.cmake do not match.\n"
+        f"find_package: {dependency_components}\n"
+        f"install-config.cmake: {install_dependency_components}"
     )
 
     print(

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "name": "bark",
   "version-semver": "0.1.0",
   "dependencies": [
-    "asio",
+    "boost-asio",
     "fmt",
     "mpmcqueue",
     "spscqueue"
@@ -17,5 +17,5 @@
       ]
     }
   },
-  "builtin-baseline": "ef7dbf94b9198bc58f45951adcf1f041fcbc5ea0"
+  "builtin-baseline": "f3e10653cc27d62a37a3763cd84b38bca07c6075"
 }


### PR DESCRIPTION
### Why 
We have downstream services that fail to compile due to using both `asio` and `boost-asio`.

### What was changed
Changed dependency on `asio` to `boost-asio`.
